### PR TITLE
Made autofill default behavior and remove the need for ViewModel to provide error properties

### DIFF
--- a/src/Helpers/ObservableDictionary.cs
+++ b/src/Helpers/ObservableDictionary.cs
@@ -1,0 +1,422 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ObservableDictionary.cs" company="MyToolkit">
+//     Copyright (c) Rico Suter. All rights reserved.
+// </copyright>
+// <license>http://mytoolkit.codeplex.com/license</license>
+// <author>Rico Suter, mail@rsuter.com</author>
+//-----------------------------------------------------------------------
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+
+namespace PropertyValidator.Helpers
+{
+    /// <summary>An implementation of an observable dictionary.</summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    public class ObservableDictionary<TKey, TValue> :
+        IDictionary<TKey, TValue>, INotifyCollectionChanged,
+        INotifyPropertyChanged, IDictionary, IReadOnlyDictionary<TKey, TValue>
+    {
+        private Dictionary<TKey, TValue> dictionary;
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        public ObservableDictionary()
+        {
+            this.dictionary = new Dictionary<TKey, TValue>();
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        /// <param name="dictionary">The dictionary to initialize this dictionary. </param>
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(dictionary);
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        /// <param name="comparer">The comparer. </param>
+        public ObservableDictionary(IEqualityComparer<TKey> comparer)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(comparer);
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        /// <param name="capacity">The capacity. </param>
+        public ObservableDictionary(int capacity)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(capacity);
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        /// <param name="dictionary">The dictionary to initialize this dictionary. </param>
+        /// <param name="comparer">The comparer. </param>
+        public ObservableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(dictionary, comparer);
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ObservableDictionary{TKey, TValue}"/> class. </summary>
+        /// <param name="capacity">The capacity. </param>
+        /// <param name="comparer">The comparer. </param>
+        public ObservableDictionary(int capacity, IEqualityComparer<TKey> comparer)
+        {
+            this.dictionary = new Dictionary<TKey, TValue>(capacity, comparer);
+        }
+
+        /// <summary>Gets the underlying dictonary. </summary>
+        protected Dictionary<TKey, TValue> Dictionary => this.dictionary;
+
+        /// <summary>Adds multiple key-value pairs the the dictionary. </summary>
+        /// <param name="items">The key-value pairs. </param>
+        public void AddRange(IDictionary<TKey, TValue> items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+
+            if (items.Count > 0)
+            {
+                if (this.dictionary.Count > 0)
+                {
+                    if (items.Keys.Any(k => this.dictionary.ContainsKey(k)))
+                    {
+                        throw new ArgumentException("An item with the same key has already been added.");
+                    }
+
+                    foreach (var pair in items)
+                    {
+                        this.dictionary.Add(pair.Key, pair.Value);
+                    }
+                }
+                else
+                {
+                    this.dictionary = new Dictionary<TKey, TValue>(items);
+                }
+
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, items.ToArray());
+            }
+        }
+
+        /// <summary>Inserts a key-value pair into the dictionary. </summary>
+        /// <param name="key">The key. </param>
+        /// <param name="value">The value. </param>
+        /// <param name="add">If true and key already exists then an exception is thrown. </param>
+        protected virtual void Insert(TKey key, TValue value, bool add)
+        {
+            if (this.dictionary.TryGetValue(key, out var item))
+            {
+                if (add)
+                {
+                    throw new ArgumentException("An item with the same key has already been added.");
+                }
+
+                if (Equals(item, value))
+                {
+                    return;
+                }
+
+                this.dictionary[key] = value;
+                OnCollectionChanged(NotifyCollectionChangedAction.Replace, new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, item));
+            }
+            else
+            {
+                this.dictionary[key] = value;
+                OnCollectionChanged(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value));
+            }
+        }
+
+        /// <summary>Called when the property has changed.</summary>
+        /// <param name="propertyName">Name of the property.</param>
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <summary>Called when the collection has changed.</summary>
+        protected void OnCollectionChanged()
+        {
+            OnPropertyChanged();
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+        }
+
+        /// <summary>Called when the collection has changed.</summary>
+        /// <param name="action">The action.</param>
+        /// <param name="changedItem">The changed item.</param>
+        protected void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> changedItem)
+        {
+            OnPropertyChanged();
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, changedItem, 0));
+        }
+
+        /// <summary>Called when the collection has changed.</summary>
+        /// <param name="action">The action.</param>
+        /// <param name="newItem">The new item.</param>
+        /// <param name="oldItem">The old item.</param>
+        protected void OnCollectionChanged(NotifyCollectionChangedAction action, KeyValuePair<TKey, TValue> newItem, KeyValuePair<TKey, TValue> oldItem)
+        {
+            OnPropertyChanged();
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, newItem, oldItem, 0));
+        }
+
+        /// <summary>Called when the collection has changed.</summary>
+        /// <param name="action">The action.</param>
+        /// <param name="newItems">The new items.</param>
+        protected void OnCollectionChanged(NotifyCollectionChangedAction action, IList newItems)
+        {
+            OnPropertyChanged();
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(action, newItems, 0));
+        }
+
+        private void OnPropertyChanged()
+        {
+            OnPropertyChanged(nameof(Count));
+            OnPropertyChanged("Item[]");
+            OnPropertyChanged(nameof(Keys));
+            OnPropertyChanged(nameof(Values));
+        }
+
+        #region IDictionary<TKey,TValue> interface
+
+        /// <summary>Adds the specified key.</summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        public void Add(TKey key, TValue value)
+        {
+            Insert(key, value, true);
+        }
+
+        /// <summary>Determines whether the specified key contains key.</summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        public bool ContainsKey(TKey key)
+        {
+            return this.dictionary.ContainsKey(key);
+        }
+
+        /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1" /> containing the keys of the <see cref="T:System.Collections.Generic.IDictionary`2" />.</summary>
+        public ICollection<TKey> Keys {
+            get { return this.dictionary.Keys; }
+        }
+
+        ICollection IDictionary.Values => this.dictionary.Values;
+
+        ICollection IDictionary.Keys => this.dictionary.Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        /// <summary>Removes the specified key.</summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">key</exception>
+        public virtual bool Remove(TKey key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            var removed = this.dictionary.Remove(key);
+            if (removed)
+            {
+                OnCollectionChanged();
+            }
+            //OnCollectionChanged(NotifyCollectionChangedAction.Remove, new KeyValuePair<TKey, TValue>(key, value));
+            return removed;
+        }
+
+        /// <summary>Tries the get value.</summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return this.dictionary.TryGetValue(key, out value);
+        }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys {
+            get { return Keys; }
+        }
+
+        /// <summary>Gets an <see cref="T:System.Collections.Generic.ICollection`1" /> containing the values in the <see cref="T:System.Collections.Generic.IDictionary`2" />.</summary>
+        public ICollection<TValue> Values => this.dictionary.Values;
+
+        /// <summary>Gets or sets the TValue with the specified key.</summary>
+        /// <value>The TValue.</value>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        public TValue this[TKey key] {
+            get => this.dictionary[key];
+            set => Insert(key, value, false);
+        }
+
+        #endregion
+
+        #region ICollection<KeyValuePair<TKey,TValue>> interface
+
+        /// <summary>Adds the specified item.</summary>
+        /// <param name="item">The item.</param>
+        public void Add(KeyValuePair<TKey, TValue> item)
+        {
+            Insert(item.Key, item.Value, true);
+        }
+
+        void IDictionary.Add(object key, object value)
+        {
+            Insert((TKey)key, (TValue)value, true);
+        }
+
+        /// <summary>Removes all items from the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
+        public void Clear()
+        {
+            if (this.dictionary.Count > 0)
+            {
+                this.dictionary.Clear();
+                OnCollectionChanged();
+            }
+        }
+
+        /// <summary>Initializes the specified key value pairs.</summary>
+        /// <param name="keyValuePairs">The key value pairs.</param>
+        public void Initialize(IEnumerable<KeyValuePair<TKey, TValue>> keyValuePairs)
+        {
+            var pairs = keyValuePairs.ToList();
+            foreach (var pair in pairs)
+            {
+                this.dictionary[pair.Key] = pair.Value;
+            }
+
+            foreach (var key in this.dictionary.Keys.Where(k => !pairs.Any(p => Equals(p.Key, k))).ToArray())
+            {
+                this.dictionary.Remove(key);
+            }
+
+            OnCollectionChanged();
+        }
+
+        /// <summary>Initializes the specified key value pairs.</summary>
+        /// <param name="keyValuePairs">The key value pairs.</param>
+        public void Initialize(IEnumerable keyValuePairs)
+        {
+            Initialize(keyValuePairs.Cast<KeyValuePair<TKey, TValue>>());
+        }
+
+        /// <summary>Determines whether [contains] [the specified key].</summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        public bool Contains(object key)
+        {
+            return ContainsKey((TKey)key);
+        }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return ((IDictionary)this.dictionary).GetEnumerator();
+        }
+
+        /// <summary>Removes the specified key.</summary>
+        /// <param name="key">The key.</param>
+        public void Remove(object key)
+        {
+            Remove((TKey)key);
+        }
+
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.IDictionary" /> object has a fixed size.</summary>
+        public bool IsFixedSize => false;
+
+        /// <summary>Determines whether [contains] [the specified item].</summary>
+        /// <param name="item">The item.</param>
+        /// <returns></returns>
+        public bool Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return this.dictionary.Contains(item);
+        }
+
+        /// <summary>Copies to.</summary>
+        /// <param name="array">The array.</param>
+        /// <param name="arrayIndex">Index of the array.</param>
+        public void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((IDictionary)this.dictionary).CopyTo(array, arrayIndex);
+        }
+
+        /// <summary>Copies to.</summary>
+        /// <param name="array">The array.</param>
+        /// <param name="index">The index.</param>
+        public void CopyTo(Array array, int index)
+        {
+            ((IDictionary)this.dictionary).CopyTo(array, index);
+        }
+
+        /// <summary>Gets the number of elements contained in the <see cref="T:System.Collections.Generic.ICollection`1" />.</summary>
+        public int Count => this.dictionary.Count;
+
+        /// <summary>Gets a value indicating whether access to the <see cref="T:System.Collections.ICollection" /> is synchronized (thread safe).</summary>
+        public bool IsSynchronized { get; private set; }
+
+        /// <summary>Gets an object that can be used to synchronize access to the <see cref="T:System.Collections.ICollection" />.</summary>
+        public object? SyncRoot { get; private set; }
+
+        /// <summary>Gets a value indicating whether the <see cref="T:System.Collections.Generic.ICollection`1" /> is read-only.</summary>
+        public bool IsReadOnly => ((IDictionary)this.dictionary).IsReadOnly;
+
+        object IDictionary.this[object key] {
+            get => this[(TKey)key];
+            set => this[(TKey)key] = (TValue)value;
+        }
+
+        /// <summary>Removes the specified item.</summary>
+        /// <param name="item">The item.</param>
+        /// <returns></returns>
+        public bool Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return Remove(item.Key);
+        }
+
+        #endregion
+
+        #region IEnumerable<KeyValuePair<TKey,TValue>> interface
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return this.dictionary.GetEnumerator();
+        }
+
+        /// <summary>Returns an enumerator that iterates through the collection.</summary>
+        /// <returns>A <see cref="T:System.Collections.Generic.IEnumerator`1" /> that can be used to iterate through the collection.</returns>
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        {
+            return this.dictionary.GetEnumerator();
+        }
+
+        #endregion
+
+        #region IEnumerable interface
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IDictionary)this.dictionary).GetEnumerator();
+        }
+
+        #endregion
+
+        #region INotifyCollectionChanged interface
+
+        /// <summary>Occurs when the collection has changed.</summary>
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        #endregion
+
+        #region INotifyPropertyChanged interface
+
+        /// <summary>Occurs when a property has changed.</summary>
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        #endregion
+    }
+}

--- a/src/Helpers/ReflectionHelper.cs
+++ b/src/Helpers/ReflectionHelper.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace PropertyValidator.Helpers
 {
-    static class ReflectionHelper
+    internal static class ReflectionHelper
     {
         public static FieldInfo? GetField(Type fromType, string fieldName)
         {

--- a/src/Models/INotifiableModel.cs
+++ b/src/Models/INotifiableModel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PropertyValidator.Models
+{
+    public interface INotifiableModel
+    {
+        void NotifyPropertyChanged();
+    }
+}

--- a/src/Models/IValidationRule.cs
+++ b/src/Models/IValidationRule.cs
@@ -4,8 +4,8 @@
     {
         string? PropertyName { get; set; }
         bool Validate(object? value);
-        string? ErrorMessage { get; }
+        string ErrorMessage { get; }
         string? ErrorMessageOverride { get; set; }
-        string? Error => ErrorMessageOverride ?? ErrorMessage;
+        string Error => ErrorMessageOverride ?? ErrorMessage;
     }
 }

--- a/src/Models/MultiValidationRule.cs
+++ b/src/Models/MultiValidationRule.cs
@@ -1,7 +1,6 @@
 ﻿using ObservableProperty.Services;
 using PropertyValidator.Services;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 
 namespace PropertyValidator.Models
@@ -20,29 +19,11 @@ namespace PropertyValidator.Models
                 return false;
             }
 
-            void Target_PropertyChanged(object sender, PropertyChangedEventArgs e)
-            {
-                var dictionaryRules = GetValidationRules();
-                var listRules = dictionaryRules.Values.SelectMany(it => it);
-                var resultArgs = ValidationService.GetValidationResultArgs(e.PropertyName, null, listRules!);
-                var isValid = resultArgs.ErrorMessages?.Any() != true;
-                if (!isValid)
-                {
-                    var inpc = sender as INotifyPropertyChanged;
-                    //resultArgs.FillErrorProperty(inpc!);
-                }
-            }
-
             if (this.validationRules == null)
             {
                 var actionCollection = new ActionCollection<T>();
                 var ruleCollection = new RuleCollection<T>(actionCollection, value);
                 this.validationRules = ConfigureRules(ruleCollection).GetRules();
-                if (value is INotifyPropertyChanged target)
-                {
-                    target.PropertyChanged -= Target_PropertyChanged;
-                    target.PropertyChanged += Target_PropertyChanged;
-                }
             }
 
             return ValidationService.ValidateRuleCollection(
@@ -63,7 +44,7 @@ namespace PropertyValidator.Models
         {
             return this.validationRules
                 .SelectMany(it => it.Value)
-                .Select(e => $"{e.PropertyName}:\"{e.ErrorMessage}\"");
+                .Select(e => $"\"{e.PropertyName}\":\"{e.Error}\"");
         }
     }
 }

--- a/src/Models/RuleAdapter.cs
+++ b/src/Models/RuleAdapter.cs
@@ -1,9 +1,0 @@
-﻿using System.Collections.Generic;
-
-namespace PropertyValidator.Models
-{
-    internal class RuleAdapter
-    {
-        private IEnumerable<IValidationRule> rules;
-    }
-}

--- a/src/Models/RuleCollection.cs
+++ b/src/Models/RuleCollection.cs
@@ -85,13 +85,16 @@ namespace PropertyValidator.Models
             string? errorMessageOverride,
             params ValidationRule<TProperty>[] rules)
         {
-            RegisterRuleFor(propertyName, rules);
+            RegisterRuleFor(propertyName, errorMessageOverride, rules);
             return this;
         }
 
-        private void RegisterRuleFor<TProperty>(string propertyName, params ValidationRule<TProperty>[] rules)
+        private void RegisterRuleFor<TProperty>(string propertyName, string? errorMessageOverride, params ValidationRule<TProperty>[] rules)
         {
-            Array.ForEach(rules, rule => rule.PropertyName = propertyName);
+            Array.ForEach(rules, rule => {
+                rule.PropertyName = propertyName;
+                rule.ErrorMessageOverride = errorMessageOverride;
+            });
             this.validationRules[propertyName] = rules;
             this.actionCollection.When<TProperty>(propertyName, it => {
                 var eventArgs = new PropertyChangedValidationEventArgs(propertyName, it);

--- a/src/Models/ValidationResultArgs.cs
+++ b/src/Models/ValidationResultArgs.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Reflection;
 
 namespace PropertyValidator.Models
 {
     public class ValidationResultArgs : EventArgs
     {
-        private const string KnownErrorPropertyPattern = "Error";
-
         public ValidationResultArgs(string? propertyName, IDictionary<string, IEnumerable<string?>> errorDictionary)
         {
             PropertyName = propertyName;
@@ -24,30 +20,9 @@ namespace PropertyValidator.Models
             .Values
             .FirstOrDefault(errors => errors.Any(message => !string.IsNullOrEmpty(message)));
 
+        public bool HasError => ErrorMessages?.Any() == true;
+
         public string? FirstError => ErrorMessages?
             .FirstOrDefault();
-
-        public void FillErrorProperty<T>(T notifiableModel) where T : INotifyPropertyChanged
-        {
-            if (PropertyName != null)
-            {
-                FillError(notifiableModel, PropertyName, FirstError);
-                return;
-            }
-
-            foreach (var (key, value) in ErrorDictionary)
-            {
-                FillError(notifiableModel, key, value.FirstOrDefault());
-            }
-        }
-
-        private void FillError<T>(T notifiableModel, string propertyName, string? errorMessage) where T : INotifyPropertyChanged
-        {
-            var errorProperty = propertyName + KnownErrorPropertyPattern;
-            var propInfo = notifiableModel.GetType().GetProperty(errorProperty);
-            if (propInfo == null)
-                throw new TargetException($"Property '{errorProperty}' not found in target '{notifiableModel.GetType().Name}'");
-            propInfo.SetValue(notifiableModel, errorMessage);
-        }
     }
 }

--- a/src/Services/IValidationService.cs
+++ b/src/Services/IValidationService.cs
@@ -1,7 +1,7 @@
 ﻿using PropertyValidator.Models;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq.Expressions;
 
 namespace PropertyValidator.Services
 {
@@ -17,9 +17,8 @@ namespace PropertyValidator.Services
         /// <returns>RuleCollection so that it can be chained</returns>
         IRuleCollection<TNotifiableModel> For<TNotifiableModel>(
             TNotifiableModel notifiableModel,
-            bool autofill = false,
             TimeSpan? delay = null)
-            where TNotifiableModel : INotifyPropertyChanged;
+            where TNotifiableModel : INotifyPropertyChanged, INotifiableModel;
 
         /// <summary>
         /// Ensure all properties are in a valid state based from the provided validation rules
@@ -32,6 +31,12 @@ namespace PropertyValidator.Services
         /// </summary>
         /// <returns></returns>
         bool Validate();
+
+        /// <summary>
+        /// Retrieves most recent errors after validating them
+        /// </summary>
+        /// <returns></returns>
+        IDictionary<string, string?> GetErrors();
 
         /// <summary>
         /// Subscribe to error events (cleared/raised)

--- a/tests/PropertyValidator.Test.Android/Properties/AndroidManifest.xml
+++ b/tests/PropertyValidator.Test.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.propertyvalidator.test" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33" />
 	<application android:label="PropertyValidator.Test.Android"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/tests/PropertyValidator.Test/Pages/ItemsPage.xaml
+++ b/tests/PropertyValidator.Test/Pages/ItemsPage.xaml
@@ -19,14 +19,14 @@
                 Text="{Binding FirstName}"
                 Placeholder="First name" />
             <Label
-                Text="{Binding FirstNameError}"
+                Text="{Binding Errors[FirstName]}"
                 TextColor="Red"
                 FontSize="Small" />
             <Entry
                 Text="{Binding LastName}"
                 Placeholder="Last name" />
             <Label
-                Text="{Binding LastNameError}"
+                Text="{Binding Errors[LastName]}"
                 TextColor="Red"
                 FontSize="Small" />
             <Entry
@@ -34,7 +34,7 @@
                 Keyboard="Email"
                 Placeholder="Email address" />
             <Label
-                Text="{Binding EmailAddressError}"
+                Text="{Binding Errors[EmailAddress]}"
                 TextColor="Red"
                 FontSize="Small" />
             <StackLayout
@@ -57,7 +57,7 @@
                     Text="{Binding PhysicalAddress.CountryIsoCode}"
                     Placeholder="2 letter ISO country code" />
                 <Label
-                    Text="{Binding PhysicalAddressError}"
+                    Text="{Binding Errors[PhysicalAddress]}"
                     TextColor="Red"
                     FontSize="Small" />
             </StackLayout>


### PR DESCRIPTION
## Change logs
- Remove `autofill` and made it the default behavior.
- Add dictionary of errors so that the ViewModel doesn't need to provide its own error properties.